### PR TITLE
Add modular VAE wrapper module

### DIFF
--- a/vae_module/__init__.py
+++ b/vae_module/__init__.py
@@ -1,0 +1,34 @@
+"""VAE wrapper module with logging and custom exceptions."""
+
+from .config import Config, load_config
+from .loader import load_vae
+from .encoder import encode, encode_batch
+from .decoder import decode, decode_batch
+from .classes import SequenceDataset, Tokenizer
+from .utils import sequence_to_tensor, tensor_to_sequence
+from .logger import setup_logger
+from .exceptions import (
+    VAEError,
+    InvalidSequenceError,
+    SequenceLengthError,
+    DeviceNotAvailableError,
+)
+
+__all__ = [
+    "Config",
+    "load_config",
+    "load_vae",
+    "encode",
+    "encode_batch",
+    "decode",
+    "decode_batch",
+    "SequenceDataset",
+    "Tokenizer",
+    "sequence_to_tensor",
+    "tensor_to_sequence",
+    "setup_logger",
+    "VAEError",
+    "InvalidSequenceError",
+    "SequenceLengthError",
+    "DeviceNotAvailableError",
+]

--- a/vae_module/classes.py
+++ b/vae_module/classes.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass
+from typing import List, Sequence
+
+import torch
+from torch.utils.data import Dataset
+
+
+@dataclass
+class Tokenizer:
+    vocab: Sequence[str]
+    pad_token: str = "<pad>"
+    bos_token: str = "<cls>"
+
+    def __post_init__(self):
+        self.idx_to_tok = list(self.vocab)
+        self.tok_to_idx = {t: i for i, t in enumerate(self.idx_to_tok)}
+        self.pad_idx = self.tok_to_idx[self.pad_token]
+        self.bos_idx = self.tok_to_idx[self.bos_token]
+
+    def get_idx(self, token: str) -> int:
+        return self.tok_to_idx[token]
+
+    def get_tok(self, idx: int) -> str:
+        return self.idx_to_tok[idx]
+
+
+class SequenceDataset(Dataset):
+    """Dataset wrapping a list of string sequences."""
+
+    def __init__(self, sequences: List[str], tokenizer: Tokenizer, max_len: int):
+        self.sequences = sequences
+        self.tokenizer = tokenizer
+        self.max_len = max_len
+
+    def __len__(self) -> int:
+        return len(self.sequences)
+
+    def __getitem__(self, idx: int) -> torch.Tensor:
+        from .utils import sequence_to_tensor
+
+        seq = self.sequences[idx]
+        return sequence_to_tensor(seq, self.tokenizer, self.max_len)

--- a/vae_module/config.py
+++ b/vae_module/config.py
@@ -1,0 +1,32 @@
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+
+@dataclass
+class Config:
+    """Configuration object for VAE settings."""
+
+    model_path: str
+    device: str = "cpu"
+    batch_size: int = 64
+    max_len: int = 512
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Config":
+        return cls(**data)
+
+
+def load_config(path: str) -> Config:
+    """Load a configuration from YAML or JSON file."""
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"Config file not found: {path}")
+    if p.suffix in {".yml", ".yaml"}:
+        data = yaml.safe_load(p.read_text())
+    else:
+        data = json.loads(p.read_text())
+    return Config.from_dict(data)

--- a/vae_module/decoder.py
+++ b/vae_module/decoder.py
@@ -1,0 +1,52 @@
+from typing import List
+
+import torch
+from tqdm import trange
+
+from .logger import setup_logger
+from .model import VAETransformerDecoder
+from .classes import Tokenizer
+from .utils import tensor_to_sequence
+
+logger = setup_logger(__name__)
+
+
+def decode(model: VAETransformerDecoder, z: torch.Tensor, tokenizer: Tokenizer, max_len: int) -> str:
+    """Decode a latent vector into a sequence."""
+    model.eval()
+    device = next(model.parameters()).device
+    z = z.unsqueeze(0).to(device)
+
+    generated = torch.full((1, max_len), tokenizer.pad_idx, device=device, dtype=torch.long)
+    generated[:, 0] = tokenizer.bos_idx
+
+    tgt_mask = torch.triu(torch.full((max_len, max_len), float("-inf"), device=device), diagonal=1)
+    memory = torch.zeros(1, max_len, model.dec_emb.embedding_dim, device=device)
+
+    with torch.no_grad():
+        for t in trange(1, max_len, disable=True):
+            tok_emb = model.dec_emb(generated[:, :t])
+            pos_emb = model.dec_pos[:, :t, :]
+            z_emb = model.latent2emb(z).unsqueeze(1).expand(-1, t, -1)
+            tgt = tok_emb + pos_emb + z_emb
+
+            dec_out = model.decoder(
+                tgt=tgt,
+                memory=memory,
+                tgt_mask=tgt_mask[:t, :t],
+            )
+
+            logits = model.out(dec_out)
+            next_token = logits[:, -1].argmax(-1)
+            generated[:, t] = next_token
+            if (next_token == tokenizer.pad_idx).all():
+                break
+
+    ids = generated[0]
+    return tensor_to_sequence(ids, tokenizer)
+
+
+def decode_batch(model: VAETransformerDecoder, Z: torch.Tensor, tokenizer: Tokenizer, max_len: int) -> List[str]:
+    """Decode a batch of latent vectors."""
+    seqs = [decode(model, z, tokenizer, max_len) for z in Z]
+    return seqs

--- a/vae_module/docs/api.rst
+++ b/vae_module/docs/api.rst
@@ -1,0 +1,14 @@
+API Reference
+=============
+
+.. automodule:: vae_module.loader
+   :members:
+
+.. automodule:: vae_module.encoder
+   :members:
+
+.. automodule:: vae_module.decoder
+   :members:
+
+.. automodule:: vae_module.exceptions
+   :members:

--- a/vae_module/docs/conf.py
+++ b/vae_module/docs/conf.py
@@ -1,0 +1,4 @@
+project = 'vae_module'
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon']
+exclude_patterns = ['_build']
+html_theme = 'alabaster'

--- a/vae_module/docs/index.rst
+++ b/vae_module/docs/index.rst
@@ -1,0 +1,8 @@
+vae_module Documentation
+=======================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   api

--- a/vae_module/encoder.py
+++ b/vae_module/encoder.py
@@ -1,0 +1,41 @@
+from typing import List
+
+import torch
+from torch.utils.data import DataLoader
+
+from .exceptions import InvalidSequenceError, SequenceLengthError
+from .logger import setup_logger
+from .utils import sequence_to_tensor
+from .classes import Tokenizer
+from .model import VAETransformerDecoder
+
+logger = setup_logger(__name__)
+
+
+def encode(model: VAETransformerDecoder, seq: str, tokenizer: Tokenizer, max_len: int) -> torch.Tensor:
+    """Encode a single sequence into a latent vector."""
+    model.eval()
+    with torch.no_grad():
+        x = sequence_to_tensor(seq, tokenizer, max_len).unsqueeze(0).to(next(model.parameters()).device)
+        mask = x != tokenizer.pad_idx
+        _, mu, logvar, *_ = model(x, mask)
+        z = mu + torch.randn_like(mu) * torch.exp(0.5 * logvar)
+        logger.debug("Encoded sequence length %d", len(seq))
+        return z.squeeze(0)
+
+
+def encode_batch(model: VAETransformerDecoder, loader: DataLoader, tokenizer: Tokenizer) -> torch.Tensor:
+    """Encode a batch of sequences from a dataloader."""
+    model.eval()
+    zs = []
+    device = next(model.parameters()).device
+    with torch.no_grad():
+        for x in loader:
+            if isinstance(x, (list, tuple)):
+                x = x[0]
+            x = x.to(device)
+            mask = x != tokenizer.pad_idx
+            _, mu, logvar, *_ = model(x, mask)
+            z = mu + torch.randn_like(mu) * torch.exp(0.5 * logvar)
+            zs.append(z.cpu())
+    return torch.cat(zs, dim=0)

--- a/vae_module/exceptions.py
+++ b/vae_module/exceptions.py
@@ -1,0 +1,14 @@
+class VAEError(Exception):
+    """Base class for VAE related errors."""
+
+
+class InvalidSequenceError(VAEError):
+    """Raised when a sequence contains invalid characters."""
+
+
+class SequenceLengthError(VAEError):
+    """Raised when a sequence is longer than the maximum allowed."""
+
+
+class DeviceNotAvailableError(VAEError):
+    """Raised when the requested device is not available."""

--- a/vae_module/loader.py
+++ b/vae_module/loader.py
@@ -1,0 +1,38 @@
+import torch
+
+from .config import Config
+from .exceptions import DeviceNotAvailableError
+from .logger import setup_logger
+from .model import SmallTransformer, VAETransformerDecoder, EMB_DIM, NUM_LAYERS, NUM_HEADS, FFN_DIM, MAX_LEN
+
+logger = setup_logger(__name__)
+
+
+def load_vae(cfg: Config, vocab_size: int, pad_idx: int, bos_idx: int) -> VAETransformerDecoder:
+    """Load VAE model from checkpoint defined in Config."""
+    device = torch.device(cfg.device)
+    if device.type == "cuda" and not torch.cuda.is_available():
+        raise DeviceNotAvailableError(cfg.device)
+
+    enc = SmallTransformer(
+        vocab_size,
+        EMB_DIM,
+        NUM_LAYERS,
+        NUM_HEADS,
+        FFN_DIM,
+        MAX_LEN,
+        pad_idx,
+    ).to(device)
+
+    model = VAETransformerDecoder(
+        encoder=enc,
+        vocab_size=vocab_size,
+        pad_token=pad_idx,
+        bos_token=bos_idx,
+    ).to(device)
+
+    checkpoint = torch.load(cfg.model_path, map_location=device)
+    model.load_state_dict(checkpoint["model_sd"])
+    model.eval()
+    logger.info("Loaded VAE from %s on %s", cfg.model_path, device)
+    return model

--- a/vae_module/logger.py
+++ b/vae_module/logger.py
@@ -1,0 +1,20 @@
+import logging
+from typing import Optional
+
+
+def setup_logger(name: str, level: str = "INFO") -> logging.Logger:
+    """Configure and return a logger with consistent format."""
+    logger = logging.getLogger(name)
+    if logger.handlers:
+        return logger
+
+    formatter = logging.Formatter(
+        fmt="%(asctime)s %(name)s [%(levelname)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(level)
+    return logger

--- a/vae_module/model.py
+++ b/vae_module/model.py
@@ -1,0 +1,92 @@
+from typing import Tuple
+
+import torch
+import torch.nn as nn
+
+DROPOUT = 0.1
+LATENT_DIM = 256
+EMB_DIM = 128
+NUM_LAYERS = 4
+NUM_HEADS = 8
+FFN_DIM = 512
+MAX_LEN = 512
+
+
+class SmallTransformer(nn.Module):
+    """Simple Transformer encoder used in the notebook."""
+
+    def __init__(self, vocab_size: int, emb_dim: int, layers: int, heads: int,
+                 ffn_dim: int, max_len: int, pad_idx: int):
+        super().__init__()
+        self.emb = nn.Embedding(vocab_size, emb_dim, padding_idx=pad_idx)
+        self.pos = nn.Parameter(torch.zeros(1, max_len, emb_dim))
+        layer = nn.TransformerEncoderLayer(
+            d_model=emb_dim,
+            nhead=heads,
+            dim_feedforward=ffn_dim,
+            batch_first=True,
+            activation="gelu",
+            dropout=DROPOUT,
+        )
+        self.enc = nn.TransformerEncoder(layer, layers)
+        self.ln = nn.LayerNorm(emb_dim)
+
+    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        mask = x != self.emb.padding_idx
+        h = self.emb(x) + self.pos[:, : x.size(1), :]
+        h = self.enc(h, src_key_padding_mask=~mask)
+        return self.ln(h), mask
+
+
+class VAETransformerDecoder(nn.Module):
+    """VAE model from the notebook."""
+
+    def __init__(self, encoder: SmallTransformer, vocab_size: int,
+                 latent_dim: int = LATENT_DIM, emb_dim: int = EMB_DIM,
+                 num_layers: int = NUM_LAYERS, num_heads: int = NUM_HEADS,
+                 ffn_dim: int = FFN_DIM, max_len: int = MAX_LEN,
+                 pad_token: int = 0, bos_token: int = 1):
+        super().__init__()
+        self.encoder = encoder
+        self.pad_token = pad_token
+        self.bos_token = bos_token
+
+        self.to_mu = nn.Linear(emb_dim, latent_dim)
+        self.to_logvar = nn.Linear(emb_dim, latent_dim)
+        self.latent2emb = nn.Linear(latent_dim, emb_dim)
+
+        self.dec_emb = nn.Embedding(vocab_size, emb_dim, padding_idx=pad_token)
+        self.dec_pos = nn.Parameter(torch.zeros(1, max_len, emb_dim))
+        layer = nn.TransformerDecoderLayer(
+            d_model=emb_dim,
+            nhead=num_heads,
+            dim_feedforward=ffn_dim,
+            dropout=DROPOUT,
+            batch_first=True,
+        )
+        self.decoder = nn.TransformerDecoder(layer, num_layers)
+        self.out = nn.Linear(emb_dim, vocab_size)
+
+    def forward(self, x: torch.Tensor, mask: torch.Tensor):
+        h_enc, enc_mask = self.encoder(x)
+        pooled = (h_enc * enc_mask.unsqueeze(-1)).sum(1) / enc_mask.sum(1, True)
+        mu, logvar = self.to_mu(pooled), self.to_logvar(pooled)
+        z = mu + torch.randn_like(mu) * torch.exp(0.5 * logvar)
+
+        B, L = x.size()
+        dec_in = torch.full((B, L), self.bos_token, device=x.device, dtype=torch.long)
+        dec_in[:, 1:] = x[:, :-1]
+        emb = self.dec_emb(dec_in) + self.dec_pos[:, :L, :]
+        z_emb = self.latent2emb(z).unsqueeze(1).expand(-1, L, -1)
+        emb = emb + z_emb
+
+        tgt_mask = nn.Transformer.generate_square_subsequent_mask(L).to(x.device)
+        h_dec = self.decoder(
+            tgt=emb,
+            memory=h_enc,
+            tgt_mask=tgt_mask,
+            tgt_key_padding_mask=~mask,
+            memory_key_padding_mask=~enc_mask,
+        )
+        logits = self.out(h_dec)
+        return logits, mu, logvar, h_enc, enc_mask

--- a/vae_module/utils.py
+++ b/vae_module/utils.py
@@ -1,0 +1,21 @@
+from typing import List
+
+import torch
+
+from .exceptions import InvalidSequenceError, SequenceLengthError
+
+
+def sequence_to_tensor(seq: str, tokenizer: "Tokenizer", max_len: int) -> torch.LongTensor:
+    """Convert a string sequence to tensor of token IDs."""
+    if any(c not in tokenizer.vocab for c in seq):
+        raise InvalidSequenceError(seq)
+    if len(seq) > max_len:
+        raise SequenceLengthError(len(seq), max_len)
+    ids = [tokenizer.get_idx(c) for c in seq]
+    return torch.tensor(ids, dtype=torch.long)
+
+
+def tensor_to_sequence(tensor: torch.Tensor, tokenizer: "Tokenizer") -> str:
+    """Convert tensor of token IDs back to string sequence."""
+    chars = [tokenizer.get_tok(int(i)) for i in tensor.tolist() if i != tokenizer.pad_idx]
+    return "".join(chars)


### PR DESCRIPTION
## Summary
- add `vae_module` package with config loader, tokenizer classes, encoder/decoder helpers, model code and logging
- include custom exceptions and Sphinx docs

## Testing
- `python -m compileall -q vae_module`

------
https://chatgpt.com/codex/tasks/task_e_684eb39929a8832b8f1c4b7cfb3dccc9