### PR TITLE
Add long sequence encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The resulting tensor `z` contains the latent representation of the sequence.
 For a more complete demonstration, see `usage_example.py` which
 shows encoding and decoding sequences from the command line.
 
+You can also encode sequences longer than 512 characters using `encode_long`, which returns a stack of latent vectors for overlapping windows.
 ## Example Scripts
 
 Several convenience scripts are included in the repository:

--- a/vae_module/__init__.py
+++ b/vae_module/__init__.py
@@ -2,7 +2,7 @@
 
 from .config import Config, load_config
 from .loader import load_vae
-from .encoder import encode, encode_batch
+from .encoder import encode, encode_batch, encode_long, encode_long_batch
 from .decoder import decode, decode_batch
 from .classes import SequenceDataset, Tokenizer
 from .utils import sequence_to_tensor, tensor_to_sequence, pad_collate
@@ -20,6 +20,8 @@ __all__ = [
     "load_vae",
     "encode",
     "encode_batch",
+    "encode_long",
+    "encode_long_batch",
     "decode",
     "decode_batch",
     "SequenceDataset",

--- a/vae_module/encoder.py
+++ b/vae_module/encoder.py
@@ -39,3 +39,60 @@ def encode_batch(model: VAETransformerDecoder, loader: DataLoader, tokenizer: To
             z = mu #+ torch.randn_like(mu) * torch.exp(0.5 * logvar)
             zs.append(z.cpu())
     return torch.cat(zs, dim=0)
+
+
+def encode_long(
+    model: VAETransformerDecoder,
+    seq: str,
+    tokenizer: Tokenizer,
+    max_len: int,
+    overlap: int = 256,
+) -> torch.Tensor:
+    """Encode a long sequence by sliding a window with overlap.
+
+    Each window has length ``max_len`` and successive windows start
+    ``max_len - overlap`` characters after the previous one. The final
+    window is padded with the pad token if needed. The latent vectors for
+    all windows are stacked in order of appearance.
+    """
+    if overlap >= max_len:
+        raise ValueError("overlap must be smaller than max_len")
+
+    if len(seq) <= max_len:
+        return encode(model, seq, tokenizer, max_len).unsqueeze(0)
+
+    step = max_len - overlap
+    segments = []
+    for start in range(0, len(seq), step):
+        end = start + max_len
+        part = seq[start:end]
+        t = sequence_to_tensor(part, tokenizer, max_len)
+        if t.size(0) < max_len:
+            pad_len = max_len - t.size(0)
+            t = torch.nn.functional.pad(t, (0, pad_len), value=tokenizer.pad_idx)
+            segments.append(t)
+            break
+        segments.append(t)
+        if end >= len(seq):
+            break
+
+    device = next(model.parameters()).device
+    x = torch.stack(segments).to(device)
+    mask = x != tokenizer.pad_idx
+    model.eval()
+    with torch.no_grad():
+        _, mu, logvar, *_ = model(x, mask)
+        z = mu
+    return z.cpu()
+
+
+def encode_long_batch(
+    model: VAETransformerDecoder,
+    sequences: List[str],
+    tokenizer: Tokenizer,
+    max_len: int,
+    overlap: int = 256,
+) -> List[torch.Tensor]:
+    """Encode a batch of long sequences using :func:`encode_long`."""
+    return [encode_long(model, s, tokenizer, max_len, overlap) for s in sequences]
+


### PR DESCRIPTION
## Summary
- support sliding-window encoding for sequences longer than 512
- expose encode_long and encode_long_batch in package
- document new helper in README

## Testing
- `python -m py_compile vae_module/encoder.py vae_module/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_685d4866bfd4832bb443b1b194cf0de5