### PR TITLE
docs: clarify license and citation requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ python protein_gym_evaluate.py --weights models/vae_epoch380.pt
 
 ## Citation
 
-If you use this code, please cite:
+If you use this code, please cite the following entry (also available in [`reference.bib`](reference.bib)):
 
 ```bibtex
 @article{ahn2025esmvae,
@@ -179,7 +179,26 @@ Code, pretrained weights, and datasets: **https://github.com/Ahnd6474/ESM-VAE**.
 
 ## License
 
-See [LICENSE](LICENSE) for full terms.
+ESM-VAE is distributed under the [ESMS‑VAE Business Source License v1.1](LICENSE).
+
+Key points:
+
+- **Non-commercial use only** – research and educational use is permitted; commercial use requires written permission from the investor "안성톱밥".
+- **Citation required** – any redistribution must include the following reference (also in [`reference.bib`](reference.bib)):
+
+```bibtex
+@article{ahn2025esmvae,
+  title={ESM VAE: A Structure-Informed Variational Autoencoder for Sequence Embedding and De Novo Protein Generation},
+  author={Ahn, Danny and Lee, Minjae and Moon, Shihyun and Jung, Jooyoung},
+  journal={Bioinformatics},
+  year={2025},
+  doi={10.1093/bioinformatics/btzXXX}
+}
+```
+
+- **Model checkpoint redistribution** – retain original directory names, include this licence file, and do not charge beyond reasonable distribution costs.
+
+Third-party dependencies and their licences are listed in [`third-party/licenses/README.md`](third-party/licenses/README.md).
 
 ---
 

--- a/reference.bib
+++ b/reference.bib
@@ -393,3 +393,10 @@
   publisher={Cold Spring Harbor Laboratory},
   doi={10.1101/2021.07.09.450648}
 }
+@article{ahn2025esmvae,
+  title={ESM VAE: A Structure-Informed Variational Autoencoder for Sequence Embedding and De Novo Protein Generation},
+  author={Ahn, Danny and Lee, Minjae and Moon, Shihyun and Jung, Jooyoung},
+  journal={Bioinformatics},
+  year={2025},
+  doi={10.1093/bioinformatics/btzXXX}
+}

--- a/third-party/licenses/README.md
+++ b/third-party/licenses/README.md
@@ -1,0 +1,12 @@
+# Third-Party Licenses
+
+| Library | License |
+| --- | --- |
+| Biopython | Biopython License Agreement (BSD-like) |
+| ESM-2 | MIT License |
+| fpbase | GPL-3.0 |
+| PyTorch | BSD-3-Clause |
+| scikit-learn | BSD-3-Clause |
+| tqdm | MPL-2.0 |
+
+See individual files in this directory for the complete license texts.


### PR DESCRIPTION
## Summary
- Clarify core terms of ESMS‑VAE Business Source License in README
- Add required BibTeX citation to reference.bib and docs
- Document third-party library licenses in a concise table

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3e0b9ad80832bb1259c565cf57495