### PR TITLE
Integrate surrogate-based decoding into VAE module

### DIFF
--- a/vae_module/__init__.py
+++ b/vae_module/__init__.py
@@ -4,6 +4,7 @@ from .config import Config, load_config
 from .loader import load_vae
 from .encoder import encode, encode_batch, encode_long, encode_long_batch
 from .decoder import decode, decode_batch
+from .model import VAEWithSurrogate, Z2MemorySurrogate
 from .classes import SequenceDataset, Tokenizer
 from .utils import sequence_to_tensor, tensor_to_sequence, pad_collate
 from .logger import setup_logger
@@ -24,6 +25,8 @@ __all__ = [
     "encode_long_batch",
     "decode",
     "decode_batch",
+    "VAEWithSurrogate",
+    "Z2MemorySurrogate",
     "SequenceDataset",
     "Tokenizer",
     "sequence_to_tensor",

--- a/vae_module/encoder.py
+++ b/vae_module/encoder.py
@@ -7,12 +7,12 @@ from .exceptions import InvalidSequenceError, SequenceLengthError
 from .logger import setup_logger
 from .utils import sequence_to_tensor
 from .classes import Tokenizer
-from .model import VAETransformerDecoder
+from .model import VAEWithSurrogate
 
 logger = setup_logger(__name__)
 
 
-def encode(model: VAETransformerDecoder, seq: str, tokenizer: Tokenizer, max_len: int) -> torch.Tensor:
+def encode(model: VAEWithSurrogate, seq: str, tokenizer: Tokenizer, max_len: int) -> torch.Tensor:
     """Encode a single sequence into a latent vector."""
     model.eval()
     with torch.no_grad():
@@ -24,7 +24,7 @@ def encode(model: VAETransformerDecoder, seq: str, tokenizer: Tokenizer, max_len
         return z.squeeze(0)
 
 
-def encode_batch(model: VAETransformerDecoder, loader: DataLoader, tokenizer: Tokenizer) -> torch.Tensor:
+def encode_batch(model: VAEWithSurrogate, loader: DataLoader, tokenizer: Tokenizer) -> torch.Tensor:
     """Encode a batch of sequences from a dataloader."""
     model.eval()
     zs = []
@@ -42,7 +42,7 @@ def encode_batch(model: VAETransformerDecoder, loader: DataLoader, tokenizer: To
 
 
 def encode_long(
-    model: VAETransformerDecoder,
+    model: VAEWithSurrogate,
     seq: str,
     tokenizer: Tokenizer,
     max_len: int,
@@ -87,7 +87,7 @@ def encode_long(
 
 
 def encode_long_batch(
-    model: VAETransformerDecoder,
+    model: VAEWithSurrogate,
     sequences: List[str],
     tokenizer: Tokenizer,
     max_len: int,


### PR DESCRIPTION
## Summary
- add `Z2MemorySurrogate` and `VAEWithSurrogate` classes to bundle surrogate memory with the VAE
- update loader to read surrogate-aware checkpoints and return the wrapped model
- enhance decoding to leverage surrogate-generated memory when available

## Testing
- `python -m py_compile vae_module/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68bb8aa6a800832b97edc23297e73fcb